### PR TITLE
 Using bzip2/1.0.6@conan/stable instead of bzip2/1.0.6@lasote/stable 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class FreetypeConan(ConanFile):
     license="MIT"
     exports_sources = "CMakeLists.txt"
     exports = "FindFreetype.cmake"
-    requires = "libpng/1.6.34@bincrafters/stable", "bzip2/1.0.6@lasote/stable"
+    requires = "libpng/1.6.34@bincrafters/stable", "bzip2/1.0.6@conan/stable"
     source_url = "http://downloads.sourceforge.net/project/freetype/freetype2/{0}".format(version)
 
     def requirements(self):


### PR DESCRIPTION
bzip2/1.0.6@lasote/stable contains deprecated methods and doesn't build any more, thus blocking the deployment of the freetype package. Referencing bzip2/1.0.6@conan/stable has corrected the problem.